### PR TITLE
Add woff2 to template also fixed woff2 and svg generation

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,6 +6,7 @@ var consolidate = require('gulp-consolidate');
 
 var fontName = 'symbols'; // set name of your symbol font
 var template = 'fontawesome-style'; // you can also choose 'foundation-style'
+var runTimestamp = Math.round(Date.now()/1000);
 
 gulp.task('symbols', function(){
   gulp.src('symbol-font-14px.sketch') // you can also choose 'symbol-font-16px.sketch'
@@ -13,7 +14,11 @@ gulp.task('symbols', function(){
       export: 'artboards',
       formats: 'svg'
     }))
-    .pipe(iconfont({ fontName: fontName }))
+    .pipe(iconfont({
+      fontName: fontName, // required
+      formats: ['svg', 'ttf', 'eot', 'woff', 'woff2'],
+      timestamp: runTimestamp // recommended to get consistent builds when watching files
+    }))
     .on('glyphs', function(glyphs) {
       var options = {
         glyphs: glyphs.map(function(glyph) {

--- a/templates/fontawesome-style.css
+++ b/templates/fontawesome-style.css
@@ -2,6 +2,7 @@
   font-family: "<%= fontName %>";
   src: url('<%= fontPath %><%= fontName %>.eot');
   src: url('<%= fontPath %><%= fontName %>.eot?#iefix') format('eot'),
+    url('<%= fontPath %><%= fontName %>.woff2') format('woff2'),
     url('<%= fontPath %><%= fontName %>.woff') format('woff'),
     url('<%= fontPath %><%= fontName %>.ttf') format('truetype'),
     url('<%= fontPath %><%= fontName %>.svg#<%= fontName %>') format('svg');

--- a/templates/foundation-style.css
+++ b/templates/foundation-style.css
@@ -2,6 +2,7 @@
   font-family: "<%= fontName %>";
   src: url('<%= fontPath %><%= fontName %>.eot');
   src: url('<%= fontPath %><%= fontName %>.eot?#iefix') format('eot'),
+    url('<%= fontPath %><%= fontName %>.woff2') format('woff2'),
     url('<%= fontPath %><%= fontName %>.woff') format('woff'),
     url('<%= fontPath %><%= fontName %>.ttf') format('truetype'),
     url('<%= fontPath %><%= fontName %>.svg#<%= fontName %>') format('svg');


### PR DESCRIPTION
This will add the approximately 30% smaller woff2 format to the generated fonts, this is also added to the templates. Improved gulpfile.js configuration fixed the problem of missing svg font.