### PR TITLE
added chars to template

### DIFF
--- a/templates/fontawesome-style.html
+++ b/templates/fontawesome-style.html
@@ -8,9 +8,9 @@
       body > h1 { color: #666; margin: 1em 0 }
       .glyph { padding: 0 }
       .glyph > li { display: inline-block; margin: .3em .2em; width: 5em; height: 6.5em; background: #fff; border-radius: .5em; position: relative }
-      .glyph > li .s { display: block; margin-top: .1em; line-height: 0 }
-      .glyph > li > i > span { position: absolute; top: 0; left: 0; text-align: center; width: 100%; color: rgba(0,0,0,0) }
-      .glyph-name { font-size: .8em; color: #666; display: block }
+      .glyph > li span:first-child { display: block; margin-top: .1em; font-size: 4em; line-height: 0 }
+      .glyph > li > .char { font-size: 4em; position: absolute; top: 0; left: 0; text-align: center; width: 100%; color: rgba(0,0,0,0) }
+      .glyph-name { font-size: .8em; color: #999; display: block }
       .glyph-codepoint { color: #999; font-family: monospace }
     </style>
   </head>
@@ -18,7 +18,8 @@
     <h1><%= fontName %></h1>
     <ul class="glyph"><% _.each(glyphs, function(glyph) { %>
       <li>
-        <i class="<%= className %> <%= className %>-<%= glyph.name %> <%= className %>-4x"><span><%= String.fromCodePoint(glyph.codepoint) %></span></i>
+        <span class="<%= className %>-<%= glyph.name %>"></span>
+        <span class="char"><%= String.fromCodePoint(glyph.codepoint) %></span>
         <span class="glyph-name"><%= glyph.name %></span>
         <span class="glyph-codepoint"><%= glyph.codepoint.toString(16).toUpperCase() %></span>
       </li><% }); %>

--- a/templates/fontawesome-style.html
+++ b/templates/fontawesome-style.html
@@ -8,9 +8,9 @@
       body > h1 { color: #666; margin: 1em 0 }
       .glyph { padding: 0 }
       .glyph > li { display: inline-block; margin: .3em .2em; width: 5em; height: 6.5em; background: #fff; border-radius: .5em; position: relative }
-      .glyph > li span:first-child { display: block; margin-top: .1em; font-size: 4em; line-height: 0 }
-      .glyph > li > .char { font-size: 4em; position: absolute; top: 0; left: 0; text-align: center; width: 100%; color: rgba(0,0,0,0) }
-      .glyph-name { font-size: .8em; color: #999; display: block }
+      .glyph > li .s { display: block; margin-top: .1em; line-height: 0 }
+      .glyph > li > i > span { position: absolute; top: 0; left: 0; text-align: center; width: 100%; color: rgba(0,0,0,0) }
+      .glyph-name { font-size: .8em; color: #666; display: block }
       .glyph-codepoint { color: #999; font-family: monospace }
     </style>
   </head>
@@ -18,8 +18,7 @@
     <h1><%= fontName %></h1>
     <ul class="glyph"><% _.each(glyphs, function(glyph) { %>
       <li>
-        <span class="<%= className %>-<%= glyph.name %>"></span>
-        <span class="char"><%= String.fromCodePoint(glyph.codepoint) %></span>
+        <i class="<%= className %> <%= className %>-<%= glyph.name %> <%= className %>-4x"><span><%= String.fromCodePoint(glyph.codepoint) %></span></i>
         <span class="glyph-name"><%= glyph.name %></span>
         <span class="glyph-codepoint"><%= glyph.codepoint.toString(16).toUpperCase() %></span>
       </li><% }); %>

--- a/templates/fontawesome-style.html
+++ b/templates/fontawesome-style.html
@@ -1,5 +1,6 @@
 <html>
   <head>
+    <meta charset="utf-8">
     <title><%= fontName %></title>
     <link href="css/<%= fontName %>.css" rel="stylesheet">
     <style>
@@ -8,6 +9,7 @@
       .glyph { padding: 0 }
       .glyph > li { display: inline-block; margin: .3em .2em; width: 5em; height: 6.5em; background: #fff; border-radius: .5em; position: relative }
       .glyph > li .s { display: block; margin-top: .1em; line-height: 0 }
+      .glyph > li > i > span { position: absolute; top: 0; left: 0; text-align: center; width: 100%; color: rgba(0,0,0,0) }
       .glyph-name { font-size: .8em; color: #666; display: block }
       .glyph-codepoint { color: #999; font-family: monospace }
     </style>
@@ -16,7 +18,7 @@
     <h1><%= fontName %></h1>
     <ul class="glyph"><% _.each(glyphs, function(glyph) { %>
       <li>
-        <i class="<%= className %> <%= className %>-<%= glyph.name %> <%= className %>-4x"></i>
+        <i class="<%= className %> <%= className %>-<%= glyph.name %> <%= className %>-4x"><span><%= String.fromCodePoint(glyph.codepoint) %></span></i>
         <span class="glyph-name"><%= glyph.name %></span>
         <span class="glyph-codepoint"><%= glyph.codepoint.toString(16).toUpperCase() %></span>
       </li><% }); %>

--- a/templates/foundation-style.html
+++ b/templates/foundation-style.html
@@ -1,5 +1,6 @@
 <html>
   <head>
+    <meta charset="utf-8">
     <title><%= fontName %></title>
     <link href="css/<%= fontName %>.css" rel="stylesheet">
     <style>
@@ -8,6 +9,7 @@
       .glyph { padding: 0 }
       .glyph > li { display: inline-block; margin: .3em .2em; width: 5em; height: 6.5em; background: #fff; border-radius: .5em; position: relative }
       .glyph > li span:first-child { display: block; margin-top: .1em; font-size: 4em; line-height: 0 }
+      .glyph > li > .char { font-size: 4em; position: absolute; top: 0; left: 0; text-align: center; width: 100%; color: rgba(0,0,0,0) }
       .glyph-name { font-size: .8em; color: #999; display: block }
       .glyph-codepoint { color: #999; font-family: monospace }
     </style>
@@ -17,6 +19,7 @@
     <ul class="glyph"><% _.each(glyphs, function(glyph) { %>
       <li>
         <span class="<%= className %>-<%= glyph.name %>"></span>
+        <span class="char"><%= String.fromCodePoint(glyph.codepoint) %></span>
         <span class="glyph-name"><%= glyph.name %></span>
         <span class="glyph-codepoint"><%= glyph.codepoint.toString(16).toUpperCase() %></span>
       </li><% }); %>


### PR DESCRIPTION
Added transparent chars to fontawesome-style.html (using css) to simulate the ability to copy and paste icons from the sample.html page into sketch.

Wrapped the chars in a span which are transparent and absolutely positioned inside the icon 
```
 <li>
````
tag inside fontawesome-style.html, this doesn't change the look of the rendered sample.html page, just allows users to highlight and copy icons into sketch