### PR TITLE
Copypaste fix

### DIFF
--- a/templates/fontawesome-style.html
+++ b/templates/fontawesome-style.html
@@ -9,7 +9,7 @@
       .glyph { padding: 0 }
       .glyph > li { display: inline-block; margin: .3em .2em; width: 5em; height: 6.5em; background: #fff; border-radius: .5em; position: relative }
       .glyph > li .s { display: block; margin-top: .1em; line-height: 0 }
-      .glyph > li > i > span { position: absolute; top: 0; left: 0; text-align: center; width: 100%; color: rgba(0,0,0,0) }
+      .glyph > li > i > span { position: absolute; top: 0; left: 0; text-align: center; width: 100%; color: rgba(0,0,0,0); line-height: 1em}
       .glyph-name { font-size: .8em; color: #666; display: block }
       .glyph-codepoint { color: #999; font-family: monospace }
     </style>


### PR DESCRIPTION
This is a very small tweak to the way we copy paste characters from the fontawesome sample.html. Just centers the highlight area. 